### PR TITLE
Fix $REMOVE operations to support dot notation for nested attributes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aws-knowledge-mcp-server": {
+      "type": "http",
+      "url": "https://knowledge-mcp.global.api.aws"
+    }
+  }
+}

--- a/packages/dynamoose/package-lock.json
+++ b/packages/dynamoose/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monei-js/dynamoose",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monei-js/dynamoose",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "funding": [
         {
           "type": "github-sponsors",

--- a/packages/dynamoose/package.json
+++ b/packages/dynamoose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monei-js/dynamoose",
-  "version": "4.1.1",
+  "version": "4.1.3",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "homepage": "https://dynamoosejs.com",
   "main": "dist/index.js",


### PR DESCRIPTION
Previously, $REMOVE operations treated dot notation paths as literal attribute names
instead of properly handling nested attribute removal. This was inconsistent with
the recently fixed $SET operations.

Changes:
- Modified array processing logic to handle $REMOVE arrays differently
- Extended dot notation parsing to work with $REMOVE array values
- Added proper path component generation for nested $REMOVE operations
- Maintained backward compatibility for non-dot notation paths

This completes the nested attribute support, making $REMOVE consistent with $SET
for handling paths like 'business.description' and 'user.profile.avatar'.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:




<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
// Code here
```

#### Model
```
// Code here
```

#### General
```
// Code here
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#----


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `----` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #---- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [ ] No


### Other:
- [ ] I have read through and followed the Contributing Guidelines
- [ ] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoose/dynamoose/blob/main/LICENSE)
- [ ] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [ ] I have filled out all fields above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled integration with an external knowledge MCP server via configuration.
- Bug Fixes
  - Improved reliability of update operations for nested and array paths, especially removals.
  - Prevented crashes from invalid dot-notation paths with clearer validation errors.
- Tests
  - Added comprehensive tests covering nested removals, mixed SET/REMOVE operations, and invalid dot-notation handling.
- Chores
  - Bumped Dynamoose package version to 4.1.3 for distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->